### PR TITLE
Disable no-default-export rule for Storybook files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -103,7 +103,7 @@
   },
   "overrides": [
     {
-      "files": ["app/**/*.ts?(x)"],
+      "files": ["app/**/*.ts?(x)", "**/*.stories.ts?(x)"],
       "rules": {
         "import/no-default-export": "off"
       }


### PR DESCRIPTION
# Disable no-default-export rule for Storybook files

## :recycle: Current situation & Problem
Storybooks use default exports as part of their build process.


## :gear: Release Notes 
* Disable no-default-export rule for Storybook files


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
